### PR TITLE
Prevent negative delay freezing game permanently

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -68,7 +68,8 @@ int main(int argc, char* args[]){
 		double IterationEnd = SDL_GetPerformanceCounter();
 		double ElapsedSeconds = (IterationEnd - IterationStart) / (double)SDL_GetPerformanceFrequency();
 		double Delay = 16.666f - (ElapsedSeconds * 1000.0f);
-		SDL_Delay(Delay);
+		if (Delay > 0)
+			SDL_Delay(std::max(0, (int) Delay));
 		
 	}
 	


### PR DESCRIPTION
The delay fix implemented in #8 introduced the ability for the time elapsed to go above 16ms, the delay targeted. When the delay calculated is negative, it silently overflows and freezes the game permanently.
This is a simple PR to only apply call `SDL_Delay` when the delay is positive.